### PR TITLE
Add comprehensive UI components

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/lib/utils';
+import Image from 'next/image';
+
+interface AvatarProps {
+  src?: string;
+  alt: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export function Avatar({ 
+  src, 
+  alt, 
+  size = 'md',
+  className 
+}: AvatarProps) {
+  const sizeClasses = {
+    sm: 'w-8 h-8',
+    md: 'w-12 h-12',
+    lg: 'w-16 h-16'
+  };
+
+  if (!src) {
+    return (
+      <div
+        className={cn(
+          sizeClasses[size],
+          'rounded-full bg-primary-100 flex items-center justify-center',
+          className
+        )}
+      >
+        <span className="text-primary-600 font-semibold">
+          {alt.charAt(0).toUpperCase()}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('relative', sizeClasses[size], className)}>
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        className="rounded-full object-cover"
+      />
+    </div>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/lib/utils';
+
+interface BadgeProps {
+  children: React.ReactNode;
+  className?: string;
+  variant?: 'default' | 'primary' | 'success' | 'warning';
+}
+
+export function Badge({ 
+  children, 
+  className,
+  variant = 'default' 
+}: BadgeProps) {
+  const variantClasses = {
+    default: 'bg-gray-100 text-gray-700',
+    primary: 'bg-primary-100 text-primary-700',
+    success: 'bg-green-100 text-green-700',
+    warning: 'bg-amber-100 text-amber-700'
+  };
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-3 py-1 rounded-full text-sm font-medium',
+        variantClasses[variant],
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Divider.tsx
+++ b/src/components/ui/Divider.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/lib/utils';
+
+interface DividerProps {
+  className?: string;
+  variant?: 'solid' | 'dashed' | 'dotted';
+}
+
+export function Divider({ 
+  className,
+  variant = 'solid' 
+}: DividerProps) {
+  return (
+    <hr
+      className={cn(
+        'border-t border-gray-200',
+        {
+          'border-dashed': variant === 'dashed',
+          'border-dotted': variant === 'dotted'
+        },
+        className
+      )}
+    />
+  );
+}

--- a/src/components/ui/GlassCard.tsx
+++ b/src/components/ui/GlassCard.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils';
+import { motion } from 'framer-motion';
+
+interface GlassCardProps {
+  children: React.ReactNode;
+  className?: string;
+  hover?: boolean;
+}
+
+export function GlassCard({ 
+  children, 
+  className,
+  hover = true 
+}: GlassCardProps) {
+  return (
+    <motion.div
+      className={cn(
+        'relative overflow-hidden rounded-2xl',
+        'backdrop-blur-xl bg-white/80 dark:bg-gray-900/80',
+        'border border-white/20',
+        'shadow-xl',
+        hover && 'hover:shadow-2xl transition-shadow duration-300',
+        className
+      )}
+      whileHover={hover ? { y: -4 } : undefined}
+      transition={{ duration: 0.3 }}
+    >
+      <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-transparent pointer-events-none" />
+      <div className="relative z-10">
+        {children}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/ui/Grid.tsx
+++ b/src/components/ui/Grid.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+
+interface GridProps {
+  children: React.ReactNode;
+  className?: string;
+  cols?: 1 | 2 | 3 | 4 | 6 | 12;
+  gap?: 'sm' | 'md' | 'lg' | 'xl';
+}
+
+export function Grid({ 
+  children, 
+  className, 
+  cols = 3,
+  gap = 'md' 
+}: GridProps) {
+  const gapClasses = {
+    sm: 'gap-4',
+    md: 'gap-6',
+    lg: 'gap-8',
+    xl: 'gap-12'
+  };
+
+  const colClasses = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-1 md:grid-cols-2',
+    3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+    4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+    6: 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6',
+    12: 'grid-cols-3 md:grid-cols-6 lg:grid-cols-12'
+  };
+
+  return (
+    <div
+      className={cn(
+        'grid',
+        colClasses[cols],
+        gapClasses[gap],
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Heading.tsx
+++ b/src/components/ui/Heading.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@/lib/utils';
+import { motion } from 'framer-motion';
+import { animations } from '@/config/animations';
+
+interface HeadingProps {
+  children: React.ReactNode;
+  className?: string;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  gradient?: boolean;
+  animate?: boolean;
+}
+
+export function Heading({ 
+  children, 
+  className, 
+  level = 2,
+  gradient = false,
+  animate = true
+}: HeadingProps) {
+  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
+  
+  const sizeClasses = {
+    1: 'text-4xl md:text-5xl lg:text-6xl font-bold',
+    2: 'text-3xl md:text-4xl lg:text-5xl font-bold',
+    3: 'text-2xl md:text-3xl lg:text-4xl font-semibold',
+    4: 'text-xl md:text-2xl lg:text-3xl font-semibold',
+    5: 'text-lg md:text-xl lg:text-2xl font-medium',
+    6: 'text-base md:text-lg lg:text-xl font-medium'
+  };
+
+  const content = (
+    <Tag
+      className={cn(
+        sizeClasses[level],
+        gradient && 'text-gradient',
+        'leading-tight',
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  );
+
+  if (!animate) return content;
+
+  return (
+    <motion.div {...animations.fadeInUp}>
+      {content}
+    </motion.div>
+  );
+}

--- a/src/components/ui/IconCard.tsx
+++ b/src/components/ui/IconCard.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils';
+import { Card } from './Card';
+import { LucideIcon } from 'lucide-react';
+
+interface IconCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  className?: string;
+  iconClassName?: string;
+}
+
+export function IconCard({ 
+  icon: Icon, 
+  title, 
+  description, 
+  className,
+  iconClassName 
+}: IconCardProps) {
+  return (
+    <Card className={cn('p-6 md:p-8 group', className)}>
+      <div className={cn(
+        'w-14 h-14 rounded-xl bg-primary-100 text-primary-600',
+        'flex items-center justify-center mb-4',
+        'group-hover:scale-110 transition-transform duration-300',
+        iconClassName
+      )}>
+        <Icon size={24} />
+      </div>
+      <h3 className="text-xl font-semibold mb-2">{title}</h3>
+      <p className="text-muted">{description}</p>
+    </Card>
+  );
+}

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils';
+import NextLink from 'next/link';
+
+interface LinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  external?: boolean;
+}
+
+export function Link({ 
+  href, 
+  children, 
+  className,
+  external = false 
+}: LinkProps) {
+  const isExternal = external || href.startsWith('http');
+  
+  if (isExternal) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          'text-primary-600 hover:text-primary-700 underline-offset-4 hover:underline transition-colors',
+          className
+        )}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <NextLink
+      href={href}
+      className={cn(
+        'text-primary-600 hover:text-primary-700 underline-offset-4 hover:underline transition-colors',
+        className
+      )}
+    >
+      {children}
+    </NextLink>
+  );
+}

--- a/src/components/ui/MotionDiv.tsx
+++ b/src/components/ui/MotionDiv.tsx
@@ -1,0 +1,20 @@
+import { motion, HTMLMotionProps } from 'framer-motion';
+import { scrollReveal } from '@/config/animations';
+
+interface MotionDivProps extends HTMLMotionProps<"div"> {
+  children: React.ReactNode;
+}
+
+export function MotionDiv({ children, ...props }: MotionDivProps) {
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={scrollReveal}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+import { Container } from './Container';
+
+interface SectionProps {
+  children: React.ReactNode;
+  className?: string;
+  containerClassName?: string;
+  id?: string;
+  fullWidth?: boolean;
+  pattern?: boolean;
+}
+
+export function Section({ 
+  children, 
+  className, 
+  containerClassName,
+  id,
+  fullWidth = false,
+  pattern = false
+}: SectionProps) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        'relative py-16 md:py-24 lg:py-32',
+        pattern && 'overflow-hidden',
+        className
+      )}
+    >
+      {pattern && (
+        <div className="absolute inset-0 bg-gradient-to-br from-primary-50/50 to-transparent" />
+      )}
+      {fullWidth ? (
+        <div className={cn('relative z-10', containerClassName)}>
+          {children}
+        </div>
+      ) : (
+        <Container className={cn('relative z-10', containerClassName)}>
+          {children}
+        </Container>
+      )}
+    </section>
+  );
+}

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -1,0 +1,47 @@
+import { cn } from '@/lib/utils';
+import { motion } from 'framer-motion';
+import { animations } from '@/config/animations';
+
+interface TextProps {
+  children: React.ReactNode;
+  className?: string;
+  size?: 'sm' | 'base' | 'lg' | 'xl';
+  muted?: boolean;
+  animate?: boolean;
+}
+
+export function Text({ 
+  children, 
+  className, 
+  size = 'base',
+  muted = false,
+  animate = false
+}: TextProps) {
+  const sizeClasses = {
+    sm: 'text-sm',
+    base: 'text-base md:text-lg',
+    lg: 'text-lg md:text-xl',
+    xl: 'text-xl md:text-2xl'
+  };
+
+  const content = (
+    <p
+      className={cn(
+        sizeClasses[size],
+        muted && 'text-muted',
+        'leading-relaxed',
+        className
+      )}
+    >
+      {children}
+    </p>
+  );
+
+  if (!animate) return content;
+
+  return (
+    <motion.div {...animations.fadeIn}>
+      {content}
+    </motion.div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,14 @@
+export { Avatar } from './Avatar';
+export { Badge } from './Badge';
+export { Button } from './Button';
+export { Card } from './Card';
+export { Container } from './Container';
+export { Divider } from './Divider';
+export { GlassCard } from './GlassCard';
+export { Grid } from './Grid';
+export { Heading } from './Heading';
+export { IconCard } from './IconCard';
+export { Link } from './Link';
+export { MotionDiv } from './MotionDiv';
+export { Section } from './Section';
+export { Text } from './Text';


### PR DESCRIPTION
## Summary
- add a full set of UI components (Grid, Section, Heading, Text, IconCard, Badge, Avatar, Link, Divider, MotionDiv, GlassCard)
- export new components from `src/components/ui/index.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6852ee7502e88329bcdd15667dc51908