### PR TITLE
Add landing page components

### DIFF
--- a/public/pattern.svg
+++ b/public/pattern.svg
@@ -1,0 +1,8 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle cx="10" cy="10" r="1.5" fill="currentColor" opacity="0.5"/>
+    </pattern>
+  </defs>
+  <rect width="100" height="100" fill="url(#grid)" />
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,51 @@
+'use client';
+
+import { useTheme } from '@/hooks/useTheme';
+import { useLPData } from '@/contexts/LPContext';
+import {
+  Header,
+  Hero,
+  Benefits,
+  HowItWorks,
+  About,
+  Testimonials,
+  CTAFinal,
+  Footer
+} from '@/components/sections';
+
 export default function Home() {
+  const lpData = useLPData();
+  
+  // Aplicar tema
+  useTheme(lpData.metadata);
+
   return (
-    <main className="min-h-screen">
-      <h1 className="text-4xl font-bold text-center py-20">
-        Modern LP Template - FASE 1
-      </h1>
-    </main>
-  )
+    <>
+      <Header content={lpData.content.header} />
+      
+      <main>
+        <Hero content={lpData.content.hero} />
+        
+        {lpData.content.benefits && (
+          <Benefits content={lpData.content.benefits} />
+        )}
+        
+        {lpData.content.howItWorks && (
+          <HowItWorks content={lpData.content.howItWorks} />
+        )}
+        
+        {lpData.content.about && (
+          <About content={lpData.content.about} />
+        )}
+        
+        {lpData.content.testimonials && (
+          <Testimonials content={lpData.content.testimonials} />
+        )}
+        
+        <CTAFinal content={lpData.content.ctaFinal} />
+      </main>
+      
+      <Footer content={lpData.content.footer} />
+    </>
+  );
 }

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { Section, Container, Heading, Text, MotionDiv } from '@/components/ui';
+import { AboutContent } from '@/types/lp';
+import { staggerContainer } from '@/config/animations';
+import { cn } from '@/lib/utils';
+
+interface AboutProps {
+  content: AboutContent;
+}
+
+export function About({ content }: AboutProps) {
+  const paragraphs = typeof content.content === 'string'
+    ? [{ paragraph: content.content }]
+    : content.content;
+
+  return (
+    <Section id="about">
+      <Container>
+        <motion.div
+          variants={staggerContainer}
+          initial="initial"
+          whileInView="animate"
+          viewport={{ once: true }}
+          className="grid lg:grid-cols-2 gap-12 items-center"
+        >
+          {/* Content */}
+          <div className="space-y-6">
+            <div>
+              <Heading level={2} gradient>
+                {content.title}
+              </Heading>
+              {content.subtitle && (
+                <Text size="lg" muted className="mt-4">
+                  {content.subtitle}
+                </Text>
+              )}
+            </div>
+
+            <div className="space-y-4">
+              {paragraphs.map((p, index) => (
+                <MotionDiv key={index}>
+                  <Text>{p.paragraph}</Text>
+                </MotionDiv>
+              ))}
+            </div>
+
+            {/* Stats */}
+            {content.stats && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                className="grid grid-cols-2 lg:grid-cols-4 gap-6 pt-6"
+              >
+                {content.stats.map((stat, index) => (
+                  <motion.div
+                    key={index}
+                    whileHover={{ scale: 1.05 }}
+                    className="text-center"
+                  >
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      whileInView={{ scale: 1 }}
+                      viewport={{ once: true }}
+                      transition={{ delay: index * 0.1, type: 'spring' }}
+                      className="text-3xl lg:text-4xl font-bold text-gradient"
+                    >
+                      {stat.value}
+                    </motion.div>
+                    <div className="text-sm text-muted mt-1">{stat.label}</div>
+                  </motion.div>
+                ))}
+              </motion.div>
+            )}
+          </div>
+
+          {/* Image */}
+          {content.image && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.8 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6 }}
+              className="relative"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-primary-200/20 to-accent/20 rounded-3xl blur-3xl" />
+              <div className="relative aspect-square rounded-3xl overflow-hidden shadow-2xl">
+                <Image
+                  src={content.image.src}
+                  alt={content.image.alt}
+                  fill
+                  className="object-cover"
+                />
+              </div>
+            </motion.div>
+          )}
+        </motion.div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/Benefits.tsx
+++ b/src/components/sections/Benefits.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Section, Container, Heading, Text, Grid, IconCard, MotionDiv } from '@/components/ui';
+import { BenefitsContent } from '@/types/lp';
+import { staggerContainer } from '@/config/animations';
+
+interface BenefitsProps {
+  content: BenefitsContent;
+}
+
+export function Benefits({ content }: BenefitsProps) {
+  return (
+    <Section id="benefits" pattern>
+      <Container>
+        <motion.div
+          variants={staggerContainer}
+          initial="initial"
+          whileInView="animate"
+          viewport={{ once: true }}
+          className="space-y-12"
+        >
+          {/* Header */}
+          <div className="text-center max-w-3xl mx-auto space-y-4">
+            <Heading level={2} gradient>
+              {content.title}
+            </Heading>
+            {content.subtitle && (
+              <Text size="lg" muted>
+                {content.subtitle}
+              </Text>
+            )}
+          </div>
+
+          {/* Benefits Grid */}
+          <Grid cols={3} gap="lg">
+            {content.items.map((item, index) => (
+              <MotionDiv
+                key={index}
+                className="group"
+                style={{
+                  transform: 'perspective(1000px) rotateX(0deg) rotateY(0deg)',
+                  transformStyle: 'preserve-3d'
+                }}
+                whileHover={{
+                  rotateX: -5,
+                  rotateY: 5,
+                  scale: 1.05,
+                  transition: { duration: 0.3 }
+                }}
+              >
+                <IconCard
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                  className="h-full hover:shadow-2xl"
+                />
+              </MotionDiv>
+            ))}
+          </Grid>
+        </motion.div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/CTAFinal.tsx
+++ b/src/components/sections/CTAFinal.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { CheckCircle2, ArrowRight } from 'lucide-react';
+import { Section, Container, Heading, Text, Button } from '@/components/ui';
+import { CTAFinalContent } from '@/types/lp';
+
+interface CTAFinalProps {
+  content: CTAFinalContent;
+}
+
+export function CTAFinal({ content }: CTAFinalProps) {
+  return (
+    <Section className="relative overflow-hidden">
+      {/* Background Pattern */}
+      <div className="absolute inset-0 bg-gradient-to-br from-primary-600 to-primary-800" />
+      <div className="absolute inset-0 bg-[url('/pattern.svg')] opacity-10" />
+      
+      <Container className="relative z-10">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="max-w-4xl mx-auto text-center text-white space-y-8"
+        >
+          {/* Urgency */}
+          {content.urgency && (
+            <motion.div
+              initial={{ scale: 0 }}
+              whileInView={{ scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ type: 'spring', delay: 0.2 }}
+            >
+              <span className="inline-flex items-center px-4 py-2 bg-accent text-white rounded-full text-sm font-semibold">
+                🔥 {content.urgency}
+              </span>
+            </motion.div>
+          )}
+
+          {/* Title */}
+          <Heading level={2} className="text-white">
+            {content.title}
+          </Heading>
+
+          {/* Subtitle */}
+          {content.subtitle && (
+            <Text size="xl" className="text-white/90">
+              {content.subtitle}
+            </Text>
+          )}
+
+          {/* Benefits */}
+          {content.benefits && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              whileInView={{ opacity: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.3 }}
+              className="flex flex-wrap justify-center gap-4"
+            >
+              {content.benefits.map((benefit) => (
+                <div key={benefit} className="flex items-center gap-2">
+                  <CheckCircle2 size={20} className="text-green-400" />
+                  <span className="text-white/90">{benefit}</span>
+                </div>
+              ))}
+            </motion.div>
+          )}
+
+          {/* CTA Button */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.4 }}
+          >
+            <Button
+              size="lg"
+              className="bg-white text-primary-600 hover:bg-gray-100 shadow-2xl group"
+              onClick={() => (window.location.href = content.cta.href)}
+            >
+              {content.cta.text}
+              <ArrowRight className="ml-2 group-hover:translate-x-1 transition-transform" />
+            </Button>
+          </motion.div>
+        </motion.div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -1,0 +1,106 @@
+import { Container, Link, DynamicIcon } from '@/components/ui';
+import { FooterContent } from '@/types/lp';
+import { Facebook, Instagram, Linkedin, Twitter, Youtube } from 'lucide-react';
+
+interface FooterProps {
+  content: FooterContent;
+}
+
+const socialIcons = {
+  facebook: Facebook,
+  instagram: Instagram,
+  linkedin: Linkedin,
+  twitter: Twitter,
+  youtube: Youtube,
+};
+
+export function Footer({ content }: FooterProps) {
+  return (
+    <footer className="bg-gray-50 border-t">
+      <Container>
+        <div className="py-12 space-y-8">
+          {/* Top Section */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+            {/* Logo */}
+            {content.logo && (
+              <div>
+                <div className="text-xl font-bold text-foreground">
+                  {content.logo.text}
+                </div>
+                {content.logo.subtitle && (
+                  <div className="text-sm text-muted mt-1">
+                    {content.logo.subtitle}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Sections */}
+            {content.sections?.map((section) => (
+              <div key={section.title}>
+                <h3 className="font-semibold mb-4">{section.title}</h3>
+                <ul className="space-y-2">
+                  {section.links.map((link) => (
+                    <li key={link.href}>
+                      <Link
+                        href={link.href}
+                        className="text-muted hover:text-foreground transition-colors no-underline"
+                      >
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+
+          <hr className="border-gray-200" />
+
+          {/* Bottom Section */}
+          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+            {/* Copyright */}
+            <div className="text-sm text-muted">
+              {content.copyright}
+            </div>
+
+            {/* Social Links */}
+            {content.social && (
+              <div className="flex items-center gap-4">
+                {content.social.map((social) => {
+                  const Icon = socialIcons[social.platform];
+                  return (
+                    <a
+                      key={social.platform}
+                      href={social.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="w-10 h-10 rounded-full bg-gray-200 hover:bg-primary-100 hover:text-primary-600 flex items-center justify-center transition-colors"
+                    >
+                      <Icon size={20} />
+                    </a>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Legal Links */}
+            {content.legal && (
+              <div className="flex items-center gap-4">
+                {content.legal.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="text-sm text-muted hover:text-foreground transition-colors no-underline"
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { Menu, X } from 'lucide-react';
+import { Container, Button, Link } from '@/components/ui';
+import { HeaderContent } from '@/types/lp';
+import { cn } from '@/lib/utils';
+
+interface HeaderProps {
+  content: HeaderContent;
+}
+
+export function Header({ content }: HeaderProps) {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 20);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <header
+      className={cn(
+        'fixed top-0 left-0 right-0 z-50 transition-all duration-300',
+        isScrolled ? 'bg-white/80 backdrop-blur-lg shadow-lg' : 'bg-transparent'
+      )}
+    >
+      <Container>
+        <nav className="flex items-center justify-between py-4">
+          {/* Logo */}
+          <Link href="/" className="flex flex-col items-start no-underline">
+            <span className="text-xl font-bold text-foreground">
+              {content.logo.text}
+            </span>
+            {content.logo.subtitle && (
+              <span className="text-sm text-muted">{content.logo.subtitle}</span>
+            )}
+          </Link>
+
+          {/* Desktop Navigation */}
+          <div className="hidden md:flex items-center gap-8">
+            {content.navigation?.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="text-foreground hover:text-primary-600 transition-colors no-underline font-medium"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+
+          {/* CTA Button */}
+          <div className="hidden md:block">
+            {content.cta && (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => (window.location.href = content.cta!.href)}
+              >
+                {content.cta.text}
+              </Button>
+            )}
+          </div>
+
+          {/* Mobile Menu Button */}
+          <button
+            className="md:hidden p-2"
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          >
+            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+          </button>
+        </nav>
+      </Container>
+
+      {/* Mobile Menu */}
+      <motion.div
+        initial={false}
+        animate={{
+          height: isMobileMenuOpen ? 'auto' : 0,
+          opacity: isMobileMenuOpen ? 1 : 0
+        }}
+        className="md:hidden overflow-hidden bg-white/95 backdrop-blur-lg"
+      >
+        <Container>
+          <div className="py-4 space-y-4">
+            {content.navigation?.map((item) => (
+              <a
+                key={item.href}
+                href={item.href}
+                className="block py-2 text-foreground hover:text-primary-600 transition-colors"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                {item.label}
+              </a>
+            ))}
+            {content.cta && (
+              <Button
+                variant="primary"
+                size="sm"
+                className="w-full"
+                onClick={() => {
+                  window.location.href = content.cta!.href;
+                  setIsMobileMenuOpen(false);
+                }}
+              >
+                {content.cta.text}
+              </Button>
+            )}
+          </div>
+        </Container>
+      </motion.div>
+    </header>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { Container, Button, Badge, Heading, Text } from '@/components/ui';
+import { HeroContent } from '@/types/lp';
+import { staggerContainer } from '@/config/animations';
+
+interface HeroProps {
+  content: HeroContent;
+}
+
+export function Hero({ content }: HeroProps) {
+  return (
+    <section className="relative min-h-screen flex items-center pt-20 overflow-hidden">
+      {/* Background com diagonal */}
+      <div className="absolute inset-0 z-0">
+        <div className="absolute inset-0 bg-gradient-to-br from-primary-50 to-background" />
+        <svg
+          className="absolute bottom-0 left-0 right-0"
+          viewBox="0 0 1440 320"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fill="rgb(var(--background))"
+            d="M0,96L48,112C96,128,192,160,288,160C384,160,480,128,576,122.7C672,117,768,139,864,154.7C960,171,1056,181,1152,165.3C1248,149,1344,107,1392,85.3L1440,64L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"
+          />
+        </svg>
+      </div>
+
+      <Container className="relative z-10">
+        <motion.div
+          variants={staggerContainer}
+          initial="initial"
+          animate="animate"
+          className="grid lg:grid-cols-2 gap-12 items-center"
+        >
+          {/* Content */}
+          <div className="space-y-6">
+            {/* Badges */}
+            {content.badges && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="flex flex-wrap gap-2"
+              >
+                {content.badges.map((badge) => (
+                  <Badge key={badge} variant="primary">
+                    {badge}
+                  </Badge>
+                ))}
+              </motion.div>
+            )}
+
+            {/* Headline */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 }}
+            >
+              <Heading level={1} gradient animate={false}>
+                {content.headline}
+              </Heading>
+            </motion.div>
+
+            {/* Subheadline */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+            >
+              <Text size="xl" muted>
+                {content.subheadline}
+              </Text>
+            </motion.div>
+
+            {/* CTAs */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}
+              className="flex flex-col sm:flex-row gap-4"
+            >
+              <Button
+                variant="primary"
+                size="lg"
+                onClick={() => (window.location.href = content.cta.primary.href)}
+              >
+                {content.cta.primary.text}
+              </Button>
+              {content.cta.secondary && (
+                <Button
+                  variant="secondary"
+                  size="lg"
+                  onClick={() => (window.location.href = content.cta.secondary!.href)}
+                >
+                  {content.cta.secondary.text}
+                </Button>
+              )}
+            </motion.div>
+          </div>
+
+          {/* Image */}
+          {content.image && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: 0.4, duration: 0.6 }}
+              className="relative"
+            >
+              <div className="relative w-full h-[400px] lg:h-[600px]">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary-200/20 to-accent/20 rounded-3xl blur-3xl" />
+                <Image
+                  src={content.image.src}
+                  alt={content.image.alt}
+                  fill
+                  className="object-cover rounded-3xl shadow-2xl"
+                  priority
+                />
+              </div>
+            </motion.div>
+          )}
+        </motion.div>
+      </Container>
+    </section>
+  );
+}

--- a/src/components/sections/HowItWorks.tsx
+++ b/src/components/sections/HowItWorks.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Section, Container, Heading, Text, DynamicIcon } from '@/components/ui';
+import { HowItWorksContent } from '@/types/lp';
+import { cn } from '@/lib/utils';
+
+interface HowItWorksProps {
+  content: HowItWorksContent;
+}
+
+export function HowItWorks({ content }: HowItWorksProps) {
+  return (
+    <Section id="how" className="bg-gradient-to-b from-background to-primary-50/30">
+      <Container>
+        <div className="space-y-12">
+          {/* Header */}
+          <div className="text-center max-w-3xl mx-auto space-y-4">
+            <Heading level={2} gradient>
+              {content.title}
+            </Heading>
+            {content.subtitle && (
+              <Text size="lg" muted>
+                {content.subtitle}
+              </Text>
+            )}
+          </div>
+
+          {/* Steps */}
+          <div className="relative">
+            {/* Connection Line */}
+            <div className="absolute top-0 left-1/2 transform -translate-x-1/2 w-1 h-full bg-gradient-to-b from-primary-200 to-primary-400 hidden lg:block" />
+            
+            <div className="space-y-8 lg:space-y-16">
+              {content.steps.map((step, index) => (
+                <motion.div
+                  key={index}
+                  initial={{ opacity: 0, x: index % 2 === 0 ? -50 : 50 }}
+                  whileInView={{ opacity: 1, x: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: index * 0.2 }}
+                  className={cn(
+                    'flex items-center gap-8',
+                    index % 2 === 0 ? 'lg:flex-row' : 'lg:flex-row-reverse'
+                  )}
+                >
+                  {/* Step Number */}
+                  <div className="flex-shrink-0">
+                    <motion.div
+                      whileHover={{ scale: 1.1, rotate: 360 }}
+                      transition={{ duration: 0.5 }}
+                      className="relative w-20 h-20 lg:w-24 lg:h-24"
+                    >
+                      <div className="absolute inset-0 bg-gradient-to-br from-primary-400 to-primary-600 rounded-full blur-xl opacity-50" />
+                      <div className="relative w-full h-full bg-gradient-to-br from-primary-500 to-primary-700 rounded-full flex items-center justify-center text-white font-bold text-2xl lg:text-3xl shadow-xl">
+                        {step.number || index + 1}
+                      </div>
+                    </motion.div>
+                  </div>
+
+                  {/* Content */}
+                  <div className={cn(
+                    'flex-1 bg-white rounded-2xl p-6 lg:p-8 shadow-xl',
+                    'hover:shadow-2xl transition-shadow duration-300'
+                  )}>
+                    <div className="flex items-start gap-4">
+                      {step.icon && (
+                        <div className="w-12 h-12 bg-primary-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                          <DynamicIcon name={step.icon} className="text-primary-600" />
+                        </div>
+                      )}
+                      <div>
+                        <h3 className="text-xl font-semibold mb-2">{step.title}</h3>
+                        <p className="text-muted">{step.description}</p>
+                      </div>
+                    </div>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronLeft, ChevronRight, Star } from 'lucide-react';
+import { Section, Container, Heading, Text, Avatar, GlassCard } from '@/components/ui';
+import { TestimonialsContent } from '@/types/lp';
+import { cn } from '@/lib/utils';
+
+interface TestimonialsProps {
+  content: TestimonialsContent;
+}
+
+export function Testimonials({ content }: TestimonialsProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const nextTestimonial = () => {
+    setCurrentIndex((prev) => (prev + 1) % content.items.length);
+  };
+
+  const previousTestimonial = () => {
+    setCurrentIndex((prev) => (prev - 1 + content.items.length) % content.items.length);
+  };
+
+  return (
+    <Section id="testimonials" className="bg-gradient-to-b from-primary-50/30 to-background">
+      <Container>
+        <div className="space-y-12">
+          {/* Header */}
+          <div className="text-center max-w-3xl mx-auto space-y-4">
+            <Heading level={2} gradient>
+              {content.title}
+            </Heading>
+            {content.subtitle && (
+              <Text size="lg" muted>
+                {content.subtitle}
+              </Text>
+            )}
+          </div>
+
+          {/* Testimonials Carousel */}
+          <div className="relative max-w-4xl mx-auto">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={currentIndex}
+                initial={{ opacity: 0, x: 100 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -100 }}
+                transition={{ duration: 0.3 }}
+              >
+                <GlassCard className="p-8 lg:p-12">
+                  {/* Quote Icon */}
+                  <div className="text-6xl text-primary-200 mb-6">"</div>
+                  
+                  {/* Content */}
+                  <blockquote className="text-lg lg:text-xl mb-6">
+                    {content.items[currentIndex].content}
+                  </blockquote>
+
+                  {/* Rating */}
+                  {content.items[currentIndex].rating && (
+                    <div className="flex gap-1 mb-6">
+                      {[...Array(5)].map((_, i) => (
+                        <Star
+                          key={i}
+                          size={20}
+                          className={cn(
+                            i < content.items[currentIndex].rating!
+                              ? 'fill-amber-400 text-amber-400'
+                              : 'text-gray-300'
+                          )}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Author */}
+                  <div className="flex items-center gap-4">
+                    <Avatar
+                      src={content.items[currentIndex].avatar}
+                      alt={content.items[currentIndex].name}
+                      size="lg"
+                    />
+                    <div>
+                      <div className="font-semibold">
+                        {content.items[currentIndex].name}
+                      </div>
+                      <div className="text-sm text-muted">
+                        {content.items[currentIndex].role}
+                      </div>
+                    </div>
+                  </div>
+                </GlassCard>
+              </motion.div>
+            </AnimatePresence>
+
+            {/* Navigation */}
+            <div className="flex justify-center gap-4 mt-8">
+              <button
+                onClick={previousTestimonial}
+                className="p-3 rounded-full bg-white shadow-lg hover:shadow-xl transition-shadow"
+              >
+                <ChevronLeft size={20} />
+              </button>
+              
+              {/* Dots */}
+              <div className="flex items-center gap-2">
+                {content.items.map((_, index) => (
+                  <button
+                    key={index}
+                    onClick={() => setCurrentIndex(index)}
+                    className={cn(
+                      'w-2 h-2 rounded-full transition-all duration-300',
+                      index === currentIndex
+                        ? 'w-8 bg-primary-500'
+                        : 'bg-gray-300'
+                    )}
+                  />
+                ))}
+              </div>
+
+              <button
+                onClick={nextTestimonial}
+                className="p-3 rounded-full bg-white shadow-lg hover:shadow-xl transition-shadow"
+              >
+                <ChevronRight size={20} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,0 +1,8 @@
+export { Header } from './Header';
+export { Hero } from './Hero';
+export { Benefits } from './Benefits';
+export { HowItWorks } from './HowItWorks';
+export { About } from './About';
+export { Testimonials } from './Testimonials';
+export { CTAFinal } from './CTAFinal';
+export { Footer } from './Footer';

--- a/src/components/ui/DynamicIcon.tsx
+++ b/src/components/ui/DynamicIcon.tsx
@@ -1,16 +1,28 @@
-import * as icons from 'lucide-react';
-import type { LucideIcon, LucideProps } from 'lucide-react';
+import { LucideIcon } from 'lucide-react';
+import * as Icons from 'lucide-react';
 
-export interface DynamicIconProps extends LucideProps {
-  name: keyof typeof icons;
+interface DynamicIconProps {
+  name?: string;
+  size?: number;
+  className?: string;
 }
 
-export function DynamicIcon({ name, ...props }: DynamicIconProps) {
-  const Icon = icons[name] as LucideIcon | undefined;
-
+export function DynamicIcon({ name, size = 24, className }: DynamicIconProps) {
+  if (!name) return null;
+  
+  // Converte o nome do ícone para o formato correto
+  // Ex: "heart" -> "Heart", "file-search" -> "FileSearch"
+  const iconName = name
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+  
+  const Icon = (Icons as any)[iconName] as LucideIcon;
+  
   if (!Icon) {
+    console.warn(`Icon "${name}" not found`);
     return null;
   }
-
-  return <Icon {...props} />;
+  
+  return <Icon size={size} className={className} />;
 }

--- a/src/components/ui/IconCard.tsx
+++ b/src/components/ui/IconCard.tsx
@@ -1,9 +1,10 @@
 import { cn } from '@/lib/utils';
 import { Card } from './Card';
+import { DynamicIcon } from './DynamicIcon';
 import { LucideIcon } from 'lucide-react';
 
 interface IconCardProps {
-  icon: LucideIcon;
+  icon?: string | LucideIcon;
   title: string;
   description: string;
   className?: string;
@@ -11,7 +12,7 @@ interface IconCardProps {
 }
 
 export function IconCard({ 
-  icon: Icon, 
+  icon, 
   title, 
   description, 
   className,
@@ -25,7 +26,11 @@ export function IconCard({
         'group-hover:scale-110 transition-transform duration-300',
         iconClassName
       )}>
-        <Icon size={24} />
+        {typeof icon === 'string' ? (
+          <DynamicIcon name={icon} size={24} />
+        ) : icon ? (
+          <icon size={24} />
+        ) : null}
       </div>
       <h3 className="text-xl font-semibold mb-2">{title}</h3>
       <p className="text-muted">{description}</p>

--- a/src/contexts/LPContext.tsx
+++ b/src/contexts/LPContext.tsx
@@ -1,0 +1,6 @@
+import lpData from '../../lp.json';
+import type { LPData } from '@/types/lp';
+
+export function useLPData(): LPData {
+  return lpData as LPData;
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import type { LPMetadata } from '@/types/lp';
+import { themes } from '@/config/theme';
+
+export function useTheme(metadata: LPMetadata) {
+  useEffect(() => {
+    const root = document.documentElement;
+    const theme = themes[metadata.theme];
+
+    if (theme) {
+      Object.entries(theme.primary).forEach(([key, value]) => {
+        root.style.setProperty(`--primary-${key}`, value as string);
+      });
+      root.style.setProperty('--background', theme.background);
+      root.style.setProperty('--foreground', theme.foreground);
+      root.style.setProperty('--muted', theme.muted);
+      root.style.setProperty('--accent', theme.accent);
+    }
+
+    if (metadata.customColors) {
+      const { primary, accent, background, foreground } = metadata.customColors;
+      if (primary) root.style.setProperty('--primary-500', primary);
+      if (accent) root.style.setProperty('--accent', accent);
+      if (background) root.style.setProperty('--background', background);
+      if (foreground) root.style.setProperty('--foreground', foreground);
+    }
+  }, [metadata]);
+}

--- a/src/types/lp.ts
+++ b/src/types/lp.ts
@@ -36,6 +36,7 @@ export interface HeaderContent {
 export interface HeroContent {
   headline: string;
   subheadline: string;
+  badges?: string[];
   cta: {
     primary: CTAButton;
     secondary?: CTAButton;
@@ -111,16 +112,25 @@ export interface CTAFinalContent {
   subtitle?: string;
   cta: CTAButton;
   benefits?: string[];
+  urgency?: string;
 }
 
 export interface FooterContent {
-  copyright: string;
-  links?: {
-    label: string;
-    href: string;
+  logo?: {
+    text: string;
+    subtitle?: string;
+  };
+  sections?: {
+    title: string;
+    links: { label: string; href: string }[];
   }[];
+  copyright: string;
   social?: {
     platform: 'facebook' | 'instagram' | 'linkedin' | 'twitter' | 'youtube';
+    href: string;
+  }[];
+  legal?: {
+    label: string;
     href: string;
   }[];
 }


### PR DESCRIPTION
## Summary
- implement custom hook and context for theming and LP data
- add multiple Landing Page sections
- update UI utilities for icons
- expand content types
- connect new sections in `page.tsx`
- add pattern SVG asset

## Testing
- `npm run type-check` *(fails: Cannot find module 'next' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685364c4ea40832999802453152844cd