### PR TITLE
Add dynamic LP metadata and theming

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,35 @@
-import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
-import './globals.css'
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import { loadLPData } from '@/lib/lp-loader';
+import { LPProvider } from '@/contexts/LPContext';
+import './globals.css';
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ['latin'] });
 
-export const metadata: Metadata = {
-  title: 'Modern LP Template',
-  description: 'Landing Page moderna com Next.js 14',
+export async function generateMetadata(): Promise<Metadata> {
+  const lpData = await loadLPData();
+
+  return {
+    title: lpData.metadata.title,
+    description: lpData.metadata.description,
+    icons: {
+      icon: lpData.metadata.favicon || '/favicon.ico',
+    },
+  };
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
+  const lpData = await loadLPData();
+
   return (
     <html lang="pt-BR">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <LPProvider data={lpData}>{children}</LPProvider>
+      </body>
     </html>
-  )
+  );
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,28 +1,51 @@
 import { useEffect } from 'react';
-import type { LPMetadata } from '@/types/lp';
 import { themes } from '@/config/theme';
+import { LPMetadata } from '@/types/lp';
 
 export function useTheme(metadata: LPMetadata) {
   useEffect(() => {
-    const root = document.documentElement;
     const theme = themes[metadata.theme];
+    if (!theme) return;
 
-    if (theme) {
-      Object.entries(theme.primary).forEach(([key, value]) => {
-        root.style.setProperty(`--primary-${key}`, value as string);
-      });
-      root.style.setProperty('--background', theme.background);
-      root.style.setProperty('--foreground', theme.foreground);
-      root.style.setProperty('--muted', theme.muted);
-      root.style.setProperty('--accent', theme.accent);
-    }
+    // Aplicar cores do tema
+    const root = document.documentElement;
 
+    // Cores do tema selecionado
+    Object.entries(theme.primary).forEach(([key, value]) => {
+      root.style.setProperty(`--primary-${key}`, value);
+    });
+
+    root.style.setProperty('--background', theme.background);
+    root.style.setProperty('--foreground', theme.foreground);
+    root.style.setProperty('--muted', theme.muted);
+    root.style.setProperty('--accent', theme.accent);
+
+    // Aplicar cores customizadas se existirem
     if (metadata.customColors) {
-      const { primary, accent, background, foreground } = metadata.customColors;
-      if (primary) root.style.setProperty('--primary-500', primary);
-      if (accent) root.style.setProperty('--accent', accent);
-      if (background) root.style.setProperty('--background', background);
-      if (foreground) root.style.setProperty('--foreground', foreground);
+      if (metadata.customColors.primary) {
+        // Converter hex para RGB se necessário
+        const rgb = hexToRgb(metadata.customColors.primary);
+        if (rgb) {
+          root.style.setProperty('--primary-500', `${rgb.r} ${rgb.g} ${rgb.b}`);
+        }
+      }
+      if (metadata.customColors.accent) {
+        const rgb = hexToRgb(metadata.customColors.accent);
+        if (rgb) {
+          root.style.setProperty('--accent', `${rgb.r} ${rgb.g} ${rgb.b}`);
+        }
+      }
     }
   }, [metadata]);
+}
+
+function hexToRgb(hex: string) {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16),
+      }
+    : null;
 }


### PR DESCRIPTION
## Summary
- dynamically load metadata from lp.json in root layout
- wrap app with LPProvider for easier access to LP data
- improve theme hook with RGB hex conversion support

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853e23e0af48329abde1e6acad1b9cb