### PR TITLE
Fix How It Works layout on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,7 @@
     --primary-700: 29 78 216;
     --primary-800: 30 64 175;
     --primary-900: 30 58 138;
-    
+
     --background: 248 250 252;
     --foreground: 15 23 42;
     --muted: 100 116 139;
@@ -25,7 +25,7 @@
   html {
     scroll-behavior: smooth;
   }
-  
+
   body {
     @apply bg-background text-foreground antialiased;
   }
@@ -83,7 +83,7 @@
 @layer utilities {
   /* Utilidades para efeitos modernos */
   .glow {
-    box-shadow: 
+    box-shadow:
       0 0 20px rgb(var(--primary-500) / 0.5),
       0 0 40px rgb(var(--primary-500) / 0.3),
       0 0 60px rgb(var(--primary-500) / 0.1);
@@ -93,3 +93,29 @@
     text-wrap: balance;
   }
 }
+
+/* Fix para How It Works no Mobile */
+@media (max-width: 768px) {
+  /* Força layout vertical no mobile */
+  #how .flex {
+    flex-direction: column !important;
+  }
+
+  /* Centraliza conteúdo */
+  #how .text-left {
+    text-align: center;
+  }
+
+  /* Ajusta largura dos cards */
+  #how .flex-1 {
+    width: 100%;
+  }
+
+  /* Remove margem negativa se houver */
+  #how [class*='flex-row-reverse'] {
+    flex-direction: column !important;
+  }
+}
+
+/* OU use esta classe utilitária no componente: */
+/* className="flex flex-col lg:flex-row" ao invés de apenas "flex" */


### PR DESCRIPTION
## Summary
- fix `How It Works` section layout at small screen sizes by adding mobile CSS rules

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing modules)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6853e95343e0832998be650529989832